### PR TITLE
Add polling of more sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ micro:bit -> webapp
 line-sens:1023,1023
 ```
 
-### Distance Sensor
+### Distance Sensor (NOT IMPLEMENTED)
+Support for the distance sensor is not implemented yet. The Gigglebot helper function causes a large jump in our program memory size.
 
 #### Direction
 micro:bit -> webapp
@@ -185,7 +186,8 @@ micro:bit -> webapp
 gyro:100,100
 ```
 
-### Compass Sensor
+### Compass Sensor (NOT IMPLEMENTED)
+Support for the compass sensor is not implemented yet. When we try it, we see unknown runtime errors.
 
 #### Direction
 micro:bit -> webapp
@@ -205,7 +207,8 @@ micro:bit -> webapp
 compass-sens:100
 ```
 
-### Magnetic Force Sensor
+### Magnetic Force Sensor (NOT IMPLEMENTED)
+Support for the magnetic force sensor is not implemented yet. When we try it, we see unknown runtime errors.
 
 #### Direction
 micro:bit -> webapp
@@ -218,11 +221,13 @@ micro:bit -> webapp
 
 | Index    | Description                 | Type   | Unit              |
 |----------|-----------------------------|--------|-------------------|
-| 0        | Magnetic force              | Number | uT                |
+| 0        | Magnetic force (x)          | Number | uT                |
+| 1        | Magnetic force (y)          | Number | uT                |
+| 2        | Magnetic force (z)          | Number | uT                |
 
 #### Example
 ```
-mag-sens:60
+mag-sens:60,80,100
 ```
 
 ### Battery Sensor
@@ -245,7 +250,8 @@ micro:bit -> webapp
 battery-sens:3300
 ```
 
-### Dew Point Sensor
+### Dew Point Sensor (NOT IMPLEMENTED)
+Support for the dew point sensor is not implemented yet. When we try it, we see unknown runtime errors.
 
 #### Direction
 micro:bit -> webapp
@@ -264,22 +270,6 @@ micro:bit -> webapp
 ```
 dewpoint-sens:24
 ```
-
-
-## TODO
-
-- [ ] Add a reference for your blocks here
-- [ ] Add "icon.png" image (300x200) in the root folder
-- [ ] Add "- beta" to the GitHub project description if you are still iterating it.
-- [ ] Turn on your automated build on https://travis-ci.org
-- [ ] Use "pxt bump" to create a tagged release on GitHub
-- [ ] Get your package reviewed and approved https://makecode.microbit.org/packages/approval
-
-Read more at https://makecode.microbit.org/packages/build-your-own
-
-## License
-
-
 
 ## Supported targets
 

--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,8 @@ bluetooth.onBluetoothConnected(() => {
   connected = true;
   basic.showIcon(IconNames.Happy);
   while (connected) {
+
+    /* Light sensors */
     const leftLightSensorValue = gigglebot.lightReadSensor(
       gigglebotWhichTurnDirection.Left
     );
@@ -38,7 +40,61 @@ bluetooth.onBluetoothConnected(() => {
         convertToText(rightLightSensorValue)
     );
 
-     basic.pause(500);
+    /* Line */
+    const leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
+    const rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
+    bluetooth.uartWriteString(
+      "line-sens:" +
+        convertToText(leftLine) +
+        "," +
+        convertToText(rightLine)
+    );
+
+    /* micro:bit temperature */
+    const microbitTemperature = input.temperature();
+    bluetooth.uartWriteString(
+      "ub-temp-sens:" +
+        convertToText(microbitTemperature)
+    );
+
+    /* Acceleration */
+    const xAcceleration = input.acceleration(Dimension.X);
+    const yAcceleration = input.acceleration(Dimension.Y);
+    const zAcceleration = input.acceleration(Dimension.Z);
+    bluetooth.uartWriteString(
+      "accel:" +
+        convertToText(xAcceleration) +
+        "," +
+        convertToText(yAcceleration) +
+        "," +
+        convertToText(zAcceleration)
+    );
+
+    /* Gyro */
+    const pitch = input.rotation(Rotation.Pitch);
+    const roll = input.rotation(Rotation.Roll);
+    bluetooth.uartWriteString(
+      "gyro:" +
+        convertToText(pitch) +
+        "," +
+        convertToText(roll)
+    );
+
+    /* Battery voltage */
+    const batteryVoltage =  gigglebot.voltageBattery();
+    bluetooth.uartWriteString(
+      "battery-sens:" +
+        convertToText(batteryVoltage)
+    );
+
+    /* micro:bit ambient light */
+    const microbitLightLevel = input.lightLevel();
+    bluetooth.uartWriteString(
+      "ub-light-sens:" +
+        convertToText(microbitLightLevel)
+    );
+
+    basic.pause(500);
   }
 });
 


### PR DESCRIPTION
This adds code to poll more sensors and send their values to the UI.

Added are:
* line sensor
* micro:bit temp
* micro:bit ambient light
* acceleration
* battery voltage
* gyro (pitch/roll)

The remaining sensors were not added, because adding them caused unknown runtime errors. I'll look into them more at some point.
* magnetic force
* compass
* dew point

The distance sensor had an interesting issue. Its helper functions from Gigglebot must be huge, because it causes our total code size to jump way up above the available space. The build tool throws an error. At first, I was worried that we were just very close to the limit without it. But when I remove the distance sensor, I can add lots more code without hitting the limit. So, I think the distance sensor helper functions are just exceptionally big. Maybe we could write our own when we want to add support.
* distance

