### PR TITLE
Stop motors on Bluetooth disconnect

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,6 +18,8 @@ input.onButtonPressed(Button.B, () => {
 
 bluetooth.onBluetoothDisconnected(() => {
   connected = false;
+  gigglebot.motorPowerAssign(gigglebotWhichMotor.Left, 0);
+  gigglebot.motorPowerAssign(gigglebotWhichMotor.Right, 0);
   basic.showIcon(IconNames.No);
 });
 

--- a/main.ts
+++ b/main.ts
@@ -18,8 +18,7 @@ input.onButtonPressed(Button.B, () => {
 
 bluetooth.onBluetoothDisconnected(() => {
   connected = false;
-  gigglebot.motorPowerAssign(gigglebotWhichMotor.Left, 0);
-  gigglebot.motorPowerAssign(gigglebotWhichMotor.Right, 0);
+  gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, 0);
   basic.showIcon(IconNames.No);
 });
 


### PR DESCRIPTION
If the rover goes out of range or otherwise disconnects, it should stop the motors to avoid running forever.