### PR TITLE
Stack size experiment

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,18 @@
 let value = 0;
 let command = "";
 let connected = false;
+let leftLightSensorValue;
+let rightLightSensorValue;
+let leftLine;
+let rightLine;
+let microbitLightLevel;
+let microbitTemperature;
+let xAcceleration;
+let yAcceleration;
+let zAcceleration;
+let pitch;
+let roll;
+let batteryVoltage;
 
 /*
  * EVENT HANDLERS
@@ -28,10 +40,10 @@ bluetooth.onBluetoothConnected(() => {
   while (connected) {
 
     /* Light sensors */
-    const leftLightSensorValue = gigglebot.lightReadSensor(
+    leftLightSensorValue = gigglebot.lightReadSensor(
       gigglebotWhichTurnDirection.Left
     );
-    const rightLightSensorValue = gigglebot.lightReadSensor(
+    rightLightSensorValue = gigglebot.lightReadSensor(
       gigglebotWhichTurnDirection.Right
     );
     bluetooth.uartWriteString(
@@ -42,8 +54,8 @@ bluetooth.onBluetoothConnected(() => {
     );
 
     /* Line */
-    const leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
-    const rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
+    leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
+    rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
     bluetooth.uartWriteString(
       "line-sens:" +
         convertToText(leftLine) +
@@ -52,16 +64,16 @@ bluetooth.onBluetoothConnected(() => {
     );
 
     /* micro:bit temperature */
-    const microbitTemperature = input.temperature();
+    microbitTemperature = input.temperature();
     bluetooth.uartWriteString(
       "ub-temp-sens:" +
         convertToText(microbitTemperature)
     );
 
     /* Acceleration */
-    const xAcceleration = input.acceleration(Dimension.X);
-    const yAcceleration = input.acceleration(Dimension.Y);
-    const zAcceleration = input.acceleration(Dimension.Z);
+    xAcceleration = input.acceleration(Dimension.X);
+    yAcceleration = input.acceleration(Dimension.Y);
+    zAcceleration = input.acceleration(Dimension.Z);
     bluetooth.uartWriteString(
       "accel:" +
         convertToText(xAcceleration) +
@@ -72,8 +84,8 @@ bluetooth.onBluetoothConnected(() => {
     );
 
     /* Gyro */
-    const pitch = input.rotation(Rotation.Pitch);
-    const roll = input.rotation(Rotation.Roll);
+    pitch = input.rotation(Rotation.Pitch);
+    roll = input.rotation(Rotation.Roll);
     bluetooth.uartWriteString(
       "gyro:" +
         convertToText(pitch) +
@@ -82,14 +94,14 @@ bluetooth.onBluetoothConnected(() => {
     );
 
     /* Battery voltage */
-    const batteryVoltage =  gigglebot.voltageBattery();
+    batteryVoltage =  gigglebot.voltageBattery();
     bluetooth.uartWriteString(
       "battery-sens:" +
         convertToText(batteryVoltage)
     );
 
     /* micro:bit ambient light */
-    const microbitLightLevel = input.lightLevel();
+    microbitLightLevel = input.lightLevel();
     bluetooth.uartWriteString(
       "ub-light-sens:" +
         convertToText(microbitLightLevel)

--- a/main.ts
+++ b/main.ts
@@ -1,21 +1,7 @@
 /*
  * GLOBAL VARIABLES
  */
-let value = 0;
-let command = "";
 let connected = false;
-let leftLightSensorValue = 0;
-let rightLightSensorValue = 0;
-let leftLine = 0;
-let rightLine = 0;
-let microbitLightLevel = 0;
-let microbitTemperature = 0;
-let xAcceleration = 0;
-let yAcceleration = 0;
-let zAcceleration = 0;
-let pitch = 0;
-let roll = 0;
-let batteryVoltage = 0;
 
 /*
  * EVENT HANDLERS
@@ -30,8 +16,6 @@ input.onButtonPressed(Button.B, () => {
 
 bluetooth.onBluetoothDisconnected(() => {
   connected = false;
-  gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, 0);
-  basic.showIcon(IconNames.No);
 });
 
 bluetooth.onBluetoothConnected(() => {
@@ -39,6 +23,8 @@ bluetooth.onBluetoothConnected(() => {
 });
 
 bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
+  let value = 0;
+  let command = "";
   command = bluetooth.uartReadUntil(serial.delimiters(Delimiters.Colon));
   if ("left-motor" === command) {
     value = parseFloat(
@@ -66,77 +52,64 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
  * ON START
  */
 bluetooth.startUartService();
-basic.showString("R"); // "R" for "ready"
+
 while(true) {
-  basic.showIcon(IconNames.Confused);
-  leftLightSensorValue = gigglebot.lightReadSensor(
-    gigglebotWhichTurnDirection.Left
-  );
-  rightLightSensorValue = gigglebot.lightReadSensor(
-    gigglebotWhichTurnDirection.Right
-  );
-  leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
-  rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
-  microbitTemperature = input.temperature();
-  xAcceleration = input.acceleration(Dimension.X);
-  yAcceleration = input.acceleration(Dimension.Y);
-  zAcceleration = input.acceleration(Dimension.Z);
-  pitch = input.rotation(Rotation.Pitch);
-  roll = input.rotation(Rotation.Roll);
-  batteryVoltage =  gigglebot.voltageBattery();
-  microbitLightLevel = input.lightLevel();
-  if (connected) {
+  if (!connected) {
+    gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, 0);
+    basic.showString("R"); // "R" for "ready"
+  } else {
+    basic.showIcon(IconNames.Happy);
 
     /* Light sensors */
     bluetooth.uartWriteString(
       "light-sens:" +
-        convertToText(leftLightSensorValue) +
+        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
         "," +
-        convertToText(rightLightSensorValue)
+        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right))
     );
 
     /* Line */
     bluetooth.uartWriteString(
       "line-sens:" +
-        convertToText(leftLine) +
+        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
         "," +
-        convertToText(rightLine)
+        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left))
     );
 
     /* micro:bit temperature */
     bluetooth.uartWriteString(
       "ub-temp-sens:" +
-        convertToText(microbitTemperature)
+        convertToText(input.temperature())
     );
 
     /* Acceleration */
     bluetooth.uartWriteString(
       "accel:" +
-        convertToText(xAcceleration) +
+        convertToText(input.acceleration(Dimension.X)) +
         "," +
-        convertToText(yAcceleration) +
+        convertToText(input.acceleration(Dimension.Y)) +
         "," +
-        convertToText(zAcceleration)
+        convertToText(input.acceleration(Dimension.Z))
     );
 
     /* Gyro */
     bluetooth.uartWriteString(
       "gyro:" +
-        convertToText(pitch) +
+        convertToText(input.rotation(Rotation.Pitch)) +
         "," +
-        convertToText(roll)
+        convertToText(input.rotation(Rotation.Roll))
     );
 
     /* Battery voltage */
     bluetooth.uartWriteString(
       "battery-sens:" +
-        convertToText(batteryVoltage)
+        convertToText(gigglebot.voltageBattery())
     );
 
     /* micro:bit ambient light */
     bluetooth.uartWriteString(
       "ub-light-sens:" +
-        convertToText(microbitLightLevel)
+        convertToText(input.lightLevel())
     );
   }
   basic.pause(500);

--- a/main.ts
+++ b/main.ts
@@ -4,18 +4,18 @@
 let value = 0;
 let command = "";
 let connected = false;
-let leftLightSensorValue;
-let rightLightSensorValue;
-let leftLine;
-let rightLine;
-let microbitLightLevel;
-let microbitTemperature;
-let xAcceleration;
-let yAcceleration;
-let zAcceleration;
-let pitch;
-let roll;
-let batteryVoltage;
+let leftLightSensorValue = 0;
+let rightLightSensorValue = 0;
+let leftLine = 0;
+let rightLine = 0;
+let microbitLightLevel = 0;
+let microbitTemperature = 0;
+let xAcceleration = 0;
+let yAcceleration = 0;
+let zAcceleration = 0;
+let pitch = 0;
+let roll = 0;
+let batteryVoltage = 0;
 
 /*
  * EVENT HANDLERS
@@ -36,79 +36,6 @@ bluetooth.onBluetoothDisconnected(() => {
 
 bluetooth.onBluetoothConnected(() => {
   connected = true;
-  basic.showIcon(IconNames.Happy);
-  while (connected) {
-
-    /* Light sensors */
-    leftLightSensorValue = gigglebot.lightReadSensor(
-      gigglebotWhichTurnDirection.Left
-    );
-    rightLightSensorValue = gigglebot.lightReadSensor(
-      gigglebotWhichTurnDirection.Right
-    );
-    bluetooth.uartWriteString(
-      "light-sens:" +
-        convertToText(leftLightSensorValue) +
-        "," +
-        convertToText(rightLightSensorValue)
-    );
-
-    /* Line */
-    leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
-    rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
-    bluetooth.uartWriteString(
-      "line-sens:" +
-        convertToText(leftLine) +
-        "," +
-        convertToText(rightLine)
-    );
-
-    /* micro:bit temperature */
-    microbitTemperature = input.temperature();
-    bluetooth.uartWriteString(
-      "ub-temp-sens:" +
-        convertToText(microbitTemperature)
-    );
-
-    /* Acceleration */
-    xAcceleration = input.acceleration(Dimension.X);
-    yAcceleration = input.acceleration(Dimension.Y);
-    zAcceleration = input.acceleration(Dimension.Z);
-    bluetooth.uartWriteString(
-      "accel:" +
-        convertToText(xAcceleration) +
-        "," +
-        convertToText(yAcceleration) +
-        "," +
-        convertToText(zAcceleration)
-    );
-
-    /* Gyro */
-    pitch = input.rotation(Rotation.Pitch);
-    roll = input.rotation(Rotation.Roll);
-    bluetooth.uartWriteString(
-      "gyro:" +
-        convertToText(pitch) +
-        "," +
-        convertToText(roll)
-    );
-
-    /* Battery voltage */
-    batteryVoltage =  gigglebot.voltageBattery();
-    bluetooth.uartWriteString(
-      "battery-sens:" +
-        convertToText(batteryVoltage)
-    );
-
-    /* micro:bit ambient light */
-    microbitLightLevel = input.lightLevel();
-    bluetooth.uartWriteString(
-      "ub-light-sens:" +
-        convertToText(microbitLightLevel)
-    );
-
-    basic.pause(500);
-  }
 });
 
 bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
@@ -140,3 +67,77 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
  */
 bluetooth.startUartService();
 basic.showString("R"); // "R" for "ready"
+while(true) {
+  basic.showIcon(IconNames.Confused);
+  leftLightSensorValue = gigglebot.lightReadSensor(
+    gigglebotWhichTurnDirection.Left
+  );
+  rightLightSensorValue = gigglebot.lightReadSensor(
+    gigglebotWhichTurnDirection.Right
+  );
+  leftLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left);
+  rightLine = gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right);
+  microbitTemperature = input.temperature();
+  xAcceleration = input.acceleration(Dimension.X);
+  yAcceleration = input.acceleration(Dimension.Y);
+  zAcceleration = input.acceleration(Dimension.Z);
+  pitch = input.rotation(Rotation.Pitch);
+  roll = input.rotation(Rotation.Roll);
+  batteryVoltage =  gigglebot.voltageBattery();
+  microbitLightLevel = input.lightLevel();
+  if (connected) {
+
+    /* Light sensors */
+    bluetooth.uartWriteString(
+      "light-sens:" +
+        convertToText(leftLightSensorValue) +
+        "," +
+        convertToText(rightLightSensorValue)
+    );
+
+    /* Line */
+    bluetooth.uartWriteString(
+      "line-sens:" +
+        convertToText(leftLine) +
+        "," +
+        convertToText(rightLine)
+    );
+
+    /* micro:bit temperature */
+    bluetooth.uartWriteString(
+      "ub-temp-sens:" +
+        convertToText(microbitTemperature)
+    );
+
+    /* Acceleration */
+    bluetooth.uartWriteString(
+      "accel:" +
+        convertToText(xAcceleration) +
+        "," +
+        convertToText(yAcceleration) +
+        "," +
+        convertToText(zAcceleration)
+    );
+
+    /* Gyro */
+    bluetooth.uartWriteString(
+      "gyro:" +
+        convertToText(pitch) +
+        "," +
+        convertToText(roll)
+    );
+
+    /* Battery voltage */
+    bluetooth.uartWriteString(
+      "battery-sens:" +
+        convertToText(batteryVoltage)
+    );
+
+    /* micro:bit ambient light */
+    bluetooth.uartWriteString(
+      "ub-light-sens:" +
+        convertToText(microbitLightLevel)
+    );
+  }
+  basic.pause(500);
+}

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,8 @@
 /*
  * GLOBAL VARIABLES
  */
-let connected = false;
+let connectEventFlag = false;
+let disconnectEventFlag = false;
 
 /*
  * EVENT HANDLERS
@@ -15,11 +16,11 @@ input.onButtonPressed(Button.B, () => {
 });
 
 bluetooth.onBluetoothDisconnected(() => {
-  connected = false;
+  disconnectEventFlag = true;
 });
 
 bluetooth.onBluetoothConnected(() => {
-  connected = true;
+  connectEventFlag = true;
 });
 
 bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
@@ -51,15 +52,23 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
 /*
  * ON START
  */
+let connected = false;
 bluetooth.startUartService();
+basic.showString("R"); // "R" for "ready"
 
 while(true) {
-  if (!connected) {
-    gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, 0);
-    basic.showString("R"); // "R" for "ready"
-  } else {
+  if (connectEventFlag) {
+    connected = true;
     basic.showIcon(IconNames.Happy);
-
+    connectEventFlag = false;
+  }
+  if (disconnectEventFlag) {
+    connected = false;
+    basic.showString("R");
+    gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, 0);
+    disconnectEventFlag = false;
+  }
+  if (connected) {
     /* Light sensors */
     bluetooth.uartWriteString(
       "light-sens:" +


### PR DESCRIPTION
I'm pretty sure I figured out the `020` errors I was getting right after connecting. I think it was neither a power problem nor a timing problem -- it was a stack memory problem.

I think the `onBluetoothConnect () => {}` executes in a space that has less available stack memory. When we had all our polling code in there, it ran out of stack space when it tried to put that function on the stack. I think that because I tried putting a `sleep` function right at the beginning of it, and I'd get the error before even executing the sleep.

I tried moving all the polling code to `basic.forever () => {}`, and it had the same problem. But then when I put it in a plain 'ole `while(true)` in the main program space, I stopped getting the error.