### PR TITLE
Set content-disposition in deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,40 +9,24 @@ cache:
   directories:
   - npm_modules
   - pxt_modules
+before_deploy:
+- sudo pip install --upgrade awscli && aws --version
 deploy:
-  - provider: s3
+  - provider: script
     skip_cleanup: true
-    access_key_id: $AWS_KEY_NAME
-    secret_access_key: $AWS_KEY_SECRET
-    bucket: rovercode-pxt
-    region: us-east-2
-    local_dir: built
-    upload_dir: prod
-    acl: public_read
-    on:
-      repo: rovercode/pxt-rovercode
-      branch: master
-  - provider: s3
-    skip_cleanup: true
-    access_key_id: $AWS_KEY_NAME
-    secret_access_key: $AWS_KEY_SECRET
-    bucket: rovercode-pxt
-    region: us-east-2
-    local_dir: built
-    upload_dir: beta
-    acl: public_read
-    on:
-      repo: rovercode/pxt-rovercode
-      branch: beta
-  - provider: s3
-    skip_cleanup: true
-    access_key_id: $AWS_KEY_NAME
-    secret_access_key: $AWS_KEY_SECRET
-    bucket: rovercode-pxt
-    region: us-east-2
-    local_dir: built
-    upload_dir: alpha
-    acl: public_read
+    script: bash deploy.sh alpha
     on:
       repo: rovercode/pxt-rovercode
       branch: alpha
+  - provider: script
+    skip_cleanup: true
+    script: bash deploy.sh beta
+    on:
+      repo: rovercode/pxt-rovercode
+      branch: beta
+  - provider: script
+    skip_cleanup: true
+    script: bash deploy.sh prod
+    on:
+      repo: rovercode/pxt-rovercode
+      branch: master

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,5 @@
+aws s3 sync \
+    --metadata TravisJobNumber=${TRAVIS_JOB_NUMBER} \
+    --acl public-read \
+    --content-disposition attachment \
+    built/ s3://rovercode-pxt/$1/


### PR DESCRIPTION
This sets the `content-disposition` on the deployed S3 file so that browsers consistently interpret the link as a file to download instead of a file to display.

To do this, I had to abandon Travis' S3 deploy and write our own script using the AWS CLI. The CLI gets its credentials from the secret env variables set up in our Travis job.