### PR TITLE
Fix light sensors; disable line sensor

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -72,18 +72,19 @@ while(true) {
     /* Light sensors */
     bluetooth.uartWriteString(
       "light-sens:" +
-        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
+        convertToText(gigglebot.lightReadSensor(gigglebotWhichTurnDirection.Left)) +
         "," +
-        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Right))
+        convertToText(gigglebot.lightReadSensor(gigglebotWhichTurnDirection.Right))
     );
 
-    /* Line */
-    bluetooth.uartWriteString(
-      "line-sens:" +
-        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
-        "," +
-        convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left))
-    );
+    // TODO: Figure out why this doesn't work with light sensors above.
+    // /* Line */
+    // bluetooth.uartWriteString(
+    //   "line-sens:" +
+    //     convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
+    //     "," +
+    //     convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left))
+    // );
 
     /* micro:bit temperature */
     bluetooth.uartWriteString(


### PR DESCRIPTION
I was accidentally reading the line sensor instead of the light sensor.
Unfortunately, when I fixed the typo, the polling loop stopped running altogether. The best I can tell, we can't poll both the light sensors and the line sensors. This could be because of code size, but there's no compiler error or runtime 050 error.

For now, I commented out the line sensor polling, since we want to support the light sensors first. We'll continue to investigate.