### PR TITLE
Add support for displaying a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ right-motor:100\n
 both-motors:-40\n
 ```
 
+### Display message
+
+#### Direction
+webapp -> micro:bit
+
+#### Identifier
+`disp`.
+
+#### Data
+| Index    | Description                 | Type   | Unit              |
+|----------|-----------------------------|--------|-------------------|
+| 0        | Message                     | String | n/a               |
+
+#### Example
+```
+disp:hello world\n
+```
+
 ### Light Sensor
 
 #### Direction

--- a/main.ts
+++ b/main.ts
@@ -29,7 +29,7 @@ bluetooth.onBluetoothConnected(() => {
 
 bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
   while (busyPolling) {
-    basic.pause(50);
+    basic.pause(10);
   }
   busyHandlingCommand = true;
   let value = 0;
@@ -55,7 +55,6 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
     message = bluetooth.uartReadUntil(serial.delimiters(Delimiters.NewLine));
     basic.showString(message);
     basic.showIcon(IconNames.Happy);
-    basic.pause(1000);
   }
   busyHandlingCommand = false;
 });
@@ -82,7 +81,7 @@ while(true) {
   if (connected) {
     /* Buttons */
     while (busyHandlingCommand) {
-      basic.pause(50);
+      basic.pause(10);
     };
     busyPolling = true;
     if (buttonAEventFlag) {

--- a/main.ts
+++ b/main.ts
@@ -79,11 +79,12 @@ while(true) {
     disconnectEventFlag = false;
   }
   if (connected) {
-    /* Buttons */
     while (busyHandlingCommand) {
       basic.pause(10);
     };
     busyPolling = true;
+
+    /* Buttons */
     if (buttonAEventFlag) {
       bluetooth.uartWriteString("button:a");
       buttonAEventFlag = false;
@@ -101,7 +102,17 @@ while(true) {
         convertToText(gigglebot.lightReadSensor(gigglebotWhichTurnDirection.Right))
     );
 
-    busyPolling = false;
+    /* Battery voltage */
+    bluetooth.uartWriteString(
+      "battery-sens:" +
+        convertToText(gigglebot.voltageBattery())
+    );
+
+    /* micro:bit temperature */
+    bluetooth.uartWriteString(
+      "ub-temp-sens:" +
+        convertToText(input.temperature())
+    );
 
     // TODO: Figure out why this doesn't work with light sensors above.
     // /* Line */
@@ -110,12 +121,6 @@ while(true) {
     //     convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left)) +
     //     "," +
     //     convertToText(gigglebot.lineReadSensor(gigglebotWhichTurnDirection.Left))
-    // );
-
-    // /* micro:bit temperature */
-    // bluetooth.uartWriteString(
-    //   "ub-temp-sens:" +
-    //     convertToText(input.temperature())
     // );
 
     // /* Acceleration */
@@ -136,17 +141,13 @@ while(true) {
     //     convertToText(input.rotation(Rotation.Roll))
     // );
 
-    // /* Battery voltage */
-    // bluetooth.uartWriteString(
-    //   "battery-sens:" +
-    //     convertToText(gigglebot.voltageBattery())
-    // );
-
     // /* micro:bit ambient light */
     // bluetooth.uartWriteString(
     //   "ub-light-sens:" +
     //     convertToText(input.lightLevel())
     // );
+
+    busyPolling = false;
   }
   basic.pause(500);
 }

--- a/main.ts
+++ b/main.ts
@@ -108,11 +108,11 @@ while(true) {
         convertToText(gigglebot.voltageBattery())
     );
 
-    /* micro:bit temperature */
-    bluetooth.uartWriteString(
-      "ub-temp-sens:" +
-        convertToText(input.temperature())
-    );
+    // /* micro:bit temperature */
+    // bluetooth.uartWriteString(
+    //   "ub-temp-sens:" +
+    //     convertToText(input.temperature())
+    // );
 
     // TODO: Figure out why this doesn't work with light sensors above.
     // /* Line */


### PR DESCRIPTION
This adds support for the `disp:hello world\n` command to display a message on the micro:bit.

There is a test program called "Display Test" in alpha. Here it is in action: https://i.imgur.com/G7OAOXm.mp4 .

I had to add some locking booleans between the UART received handler and the main loop to prevent the `020` error. Unfortunately, I also had to comment out the currently unused sensor polling, because they causes `020` errors. I'm not sure yet if it was a timing/threading issue or a heap-size issue.