### PR TITLE
Speed up message scroll speed

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -76,7 +76,7 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
     gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, value);
   } else if ("disp" === command) {
     message = bluetooth.uartReadUntil(serial.delimiters(Delimiters.NewLine));
-    basic.showString(message);
+    basic.showString(message, 75);
     basic.showIcon(IconNames.Happy);
   }
   busyHandlingCommand = false;
@@ -89,8 +89,8 @@ let connected = false;
 bluetooth.startUartService();
 basic.pause(500);
 basic.showString("R");
-basic.pause(2000);
-basic.showString(control.deviceName());
+basic.pause(1500);
+basic.showString(control.deviceName(), 75);
 basic.showString("R");
 
 while(true) {

--- a/main.ts
+++ b/main.ts
@@ -76,7 +76,7 @@ bluetooth.onUartDataReceived(serial.delimiters(Delimiters.NewLine), () => {
     gigglebot.motorPowerAssign(gigglebotWhichMotor.Both, value);
   } else if ("disp" === command) {
     message = bluetooth.uartReadUntil(serial.delimiters(Delimiters.NewLine));
-    basic.showString(message, 75);
+    basic.showString(message, 100);
     basic.showIcon(IconNames.Happy);
   }
   busyHandlingCommand = false;
@@ -90,7 +90,7 @@ bluetooth.startUartService();
 basic.pause(500);
 basic.showString("R");
 basic.pause(1500);
-basic.showString(control.deviceName(), 75);
+basic.showString(control.deviceName(), 125);
 basic.showString("R");
 
 while(true) {


### PR DESCRIPTION
Increases LED matrix message scroll speed. This seem to decrease the rate of 020 errors that occur after the message has displayed. It's an alternative to increasing the next-command delay in the UI.